### PR TITLE
EDU-77 chore: GitHub For Jira 커밋 메시지 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    //git-hooks
+    id 'com.github.jakemarsden.git-hooks' version '0.0.2'
 }
 
 group = 'com.education'
@@ -38,4 +40,12 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+gitHooks {
+    hooksDirectory = file('.git/hooks')   // or '.githooks'
+    hooks = [
+            'prepare-commit-msg': file('githooks-src/prepare-commit-msg').absolutePath,
+            'commit-msg'        : file('githooks-src/commit-msg').absolutePath
+    ]
 }

--- a/githooks-src/commit-msg
+++ b/githooks-src/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+MSG=$(cat "$1")
+PAT="^([A-Z]+-[0-9]+) (feat|fix|docs|style|refactor|test|chore)(\(.+\))?: .{1,72}"
+[[ "$MSG" =~ $PAT ]] || { echo -e "\n❌  커밋 메시지 형식 오류!"; exit 1; }

--- a/githooks-src/prepare-commit-msg
+++ b/githooks-src/prepare-commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+FILE="$1"
+BRANCH="$(git symbolic-ref --short HEAD)"
+if [[ "$BRANCH" =~ ([A-Z]+-[0-9]+) ]]; then
+  ISSUE="${BASH_REMATCH[1]}"
+  grep -q "$ISSUE" "$FILE" || sed -i.bak "1s/^/$ISSUE /" "$FILE"
+fi


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- GitHub For Jira 커밋 메시지 연동 자동화

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [x] 기타 (직접 작성)

### 🔍 상세 내용
- GitHub For Jira 커밋 메시지 연동 자동화
- 기존 Git 커밋 컨벤션에 따라서 작업해도 Jira연동 가능

## 🧪 테스트 방법 (선택)
- [x] 로컬 테스트 완료
- [ ] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- https://github.com/jakemarsden/git-hooks-gradle-plugin/tree/master
