### PR TITLE
Edu 405 fix: 액세스 토큰 재발급 로직

### DIFF
--- a/src/main/java/com/education/takeit/global/config/SecurityConfig.java
+++ b/src/main/java/com/education/takeit/global/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.education.takeit.global.config;
 import com.education.takeit.global.security.JwtAuthenticationFilter;
 import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.global.security.service.CustomUserDetailService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +16,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -65,7 +66,8 @@ public class SecurityConfig {
                         "/api/user/oauth/naver", // OAuth2 경로 허용
                         "/login/**", // 로그인 경로 허용
                         "/api/user/check-email", // 회원가입시 이메일 중복확인
-                        "/api/diagnosis" // 진단 경로
+                        "/api/diagnosis", // 진단 경로
+                        "api/user/refresh" // 리프레시 토큰 발급
                         )
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/com/education/takeit/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/education/takeit/global/security/JwtAuthenticationFilter.java
@@ -1,34 +1,43 @@
 package com.education.takeit.global.security;
 
+import com.education.takeit.global.dto.Message;
+import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.security.service.CustomUserDetailService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
+import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtUtils jwtUtils;
   private final CustomUserDetailService customUserDetailService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
   private final List<String> EXCLUDE_PATHS =
       List.of(
           "/api/auth/**",
-          "/swagger-ui",
-          "/swagger-ui.html",
-          "/v3/api-docs",
-          "/swagger-resources",
           "/api/user/signin",
           "/api/user/signup",
+          "/api/user/check-email",
+          "/api/user/refresh",
           "/error",
-          "/api/user/check-email");
+          "/swagger-ui/**",
+          "/swagger-ui.html",
+          "/v3/api-docs/**",
+          "/swagger-resources/**");
 
   public JwtAuthenticationFilter(
       JwtUtils jwtUtils, CustomUserDetailService customUserDetailService) {
@@ -37,35 +46,48 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   @Override
-  protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-      throws ServletException, IOException {
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+          throws ServletException, IOException {
 
-    String token = resolveToken(request); // 1. 헤더에서 토큰 꺼냄
+    try {
+      String token = resolveToken(request);
 
-    if (token != null && jwtUtils.validateToken(token)) {
+      // 1. 토큰이 없으면 다음 필터로 넘기되, 인증은 하지 않음
+      if (token == null) {
+        filterChain.doFilter(request, response);
+        return;
+      }
+
+      // 2. 토큰이 있지만 유효하지 않으면 예외 발생 → 직접 401 응답
+      if (!jwtUtils.validateToken(token)) {
+        setErrorResponse(response, StatusCode.INVALID_TOKEN);
+        return;
+      }
+
+      // 3. 유효한 토큰이라면 인증 수행
       Long userId = jwtUtils.getUserId(token);
-
-      // UserDetailsService 등을 통해 사용자 정보 조회
       UserDetails userDetails = customUserDetailService.loadUserByUsername(userId.toString());
 
-      // 인증 객체 생성
       UsernamePasswordAuthenticationToken authentication =
-          new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+              new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
       authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-      // SecurityContextHolder에 인증 객체 등록
       SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
 
-    filterChain.doFilter(request, response);
+      filterChain.doFilter(request, response);
+
+    } catch (ExpiredJwtException e) {
+      setErrorResponse(response, StatusCode.UNAUTHORIZED); // 401
+    } catch (JwtException | IllegalArgumentException e) {
+      setErrorResponse(response, StatusCode.INVALID_TOKEN); // 401
+    }
   }
+
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
     String uri = request.getRequestURI();
-    return EXCLUDE_PATHS.stream().anyMatch(uri::startsWith);
+    return EXCLUDE_PATHS.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
   }
 
   private String resolveToken(HttpServletRequest request) {
@@ -75,4 +97,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
     return null;
   }
+
+  private void setErrorResponse(HttpServletResponse response, StatusCode status) {
+    response.setStatus(status.getStatusCode());
+    response.setContentType("application/json;charset=UTF-8");
+    try {
+      Message errorMessage = new Message(StatusCode.INVALID_TOKEN, objectMapper.writeValueAsString(status));
+      String json = objectMapper.writeValueAsString(errorMessage);
+      response.getWriter().write(json);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
 }

--- a/src/main/java/com/education/takeit/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/education/takeit/global/security/JwtAuthenticationFilter.java
@@ -10,6 +10,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,8 +19,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtUtils jwtUtils;
@@ -47,8 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-          throws ServletException, IOException {
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
 
     try {
       String token = resolveToken(request);
@@ -70,7 +71,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       UserDetails userDetails = customUserDetailService.loadUserByUsername(userId.toString());
 
       UsernamePasswordAuthenticationToken authentication =
-              new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+          new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
       authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
       SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -83,7 +84,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       setErrorResponse(response, StatusCode.INVALID_TOKEN); // 401
     }
   }
-
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -103,12 +103,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     response.setStatus(status.getStatusCode());
     response.setContentType("application/json;charset=UTF-8");
     try {
-      Message errorMessage = new Message(StatusCode.INVALID_TOKEN, objectMapper.writeValueAsString(status));
+      Message errorMessage =
+          new Message(StatusCode.INVALID_TOKEN, objectMapper.writeValueAsString(status));
       String json = objectMapper.writeValueAsString(errorMessage);
       response.getWriter().write(json);
     } catch (IOException e) {
       e.printStackTrace();
     }
   }
-
 }

--- a/src/main/java/com/education/takeit/global/security/JwtUtils.java
+++ b/src/main/java/com/education/takeit/global/security/JwtUtils.java
@@ -4,13 +4,12 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
-
 import java.security.Key;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -112,5 +111,4 @@ public class JwtUtils {
     }
     return bearerToken;
   }
-
 }

--- a/src/main/java/com/education/takeit/global/security/JwtUtils.java
+++ b/src/main/java/com/education/takeit/global/security/JwtUtils.java
@@ -17,7 +17,7 @@ public class JwtUtils {
   private final RedisTemplate<String, String> redisTemplate;
 
   private String secretKey = "AbcDefGhijkLmnOpQRStuvwXYZ1234567890!@#"; // 임시
-  private final long accessTokenExpiration = 1000L * 60 * 1; // 액세스 토큰 유효시간 : 15분
+  private final long accessTokenExpiration = 1000L * 60 * 15; // 액세스 토큰 유효시간 : 15분
   private final long refreshTokenExpiration = 1000L * 60 * 60 * 24 * 7; // 리프레시 토큰 유효시간 : 7일
 
   private Key key;

--- a/src/main/java/com/education/takeit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/education/takeit/oauth/controller/OAuthController.java
@@ -6,6 +6,7 @@ import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.service.GoogleOAuthService;
 import com.education.takeit.oauth.service.KakaoOAuthService;
 import com.education.takeit.oauth.service.NaverOAuthService;
+import com.education.takeit.user.dto.UserSigninResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,14 +33,13 @@ public class OAuthController {
   @PostMapping("/google/login")
   @Operation(summary = "Google OAuth 소셜 로그인", description = "Google OAuth 소셜 로그인 API")
   public ResponseEntity<Message> loginWithGoogle(@RequestBody OAuthLoginRequest request) {
-    String accessToken = googleOAuthService.login(request);
+    UserSigninResDto userSigninResDto = googleOAuthService.login(request);
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Authorization", "Bearer " + accessToken);
+    headers.add("Authorization", "Bearer " + userSigninResDto.accessToken());
 
-    Message message = new Message(StatusCode.OK);
 
-    return ResponseEntity.ok().headers(headers).body(message);
+    return ResponseEntity.ok().headers(headers).body(new Message(StatusCode.OK, userSigninResDto));
   }
 
   /**
@@ -51,26 +51,31 @@ public class OAuthController {
   @PostMapping("/kakao/login")
   @Operation(summary = "Kakao OAuth 소셜 로그인", description = "Kakao OAuth 소셜 로그인 API")
   public ResponseEntity<Message> loginWithKakao(@RequestBody OAuthLoginRequest request) {
-    String accessToken = kakaoOAuthService.login(request);
+    UserSigninResDto userSigninResDto = kakaoOAuthService.login(request);
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Authorization", "Bearer " + accessToken);
+    headers.add("Authorization", "Bearer " + userSigninResDto.accessToken());
 
     Message message = new Message(StatusCode.OK);
 
-    return ResponseEntity.ok().headers(headers).body(message);
+    return ResponseEntity.ok().headers(headers).body(new Message(StatusCode.OK, userSigninResDto));
   }
 
+  /**
+   *
+   * @param request
+   * @return
+   */
   @PostMapping("/naver/login")
   @Operation(summary = "Naver OAuth 소셜 로그인", description = "Naver OAuth 소셜 로그인 API")
   public ResponseEntity<Message> loginWithNaver(@RequestBody OAuthLoginRequest request) {
-    String accessToken = naverOAuthService.login(request);
+    UserSigninResDto userSigninResDto = naverOAuthService.login(request);
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Authorization", "Bearer " + accessToken);
+    headers.add("Authorization", "Bearer " + userSigninResDto.accessToken());
 
     Message message = new Message(StatusCode.OK);
 
-    return ResponseEntity.ok().headers(headers).body(message);
+    return ResponseEntity.ok().headers(headers).body(new Message(StatusCode.OK, userSigninResDto));
   }
 }

--- a/src/main/java/com/education/takeit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/education/takeit/oauth/controller/OAuthController.java
@@ -38,7 +38,6 @@ public class OAuthController {
     HttpHeaders headers = new HttpHeaders();
     headers.add("Authorization", "Bearer " + userSigninResDto.accessToken());
 
-
     return ResponseEntity.ok().headers(headers).body(new Message(StatusCode.OK, userSigninResDto));
   }
 
@@ -62,7 +61,6 @@ public class OAuthController {
   }
 
   /**
-   *
    * @param request
    * @return
    */

--- a/src/main/java/com/education/takeit/oauth/dto/OAuthTokenResponse.java
+++ b/src/main/java/com/education/takeit/oauth/dto/OAuthTokenResponse.java
@@ -14,6 +14,9 @@ public class OAuthTokenResponse {
   @JsonProperty("access_token")
   private String accessToken;
 
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
   @JsonProperty("id_token")
   private String idToken;
 

--- a/src/main/java/com/education/takeit/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/GoogleOAuthService.java
@@ -6,6 +6,7 @@ import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.GoogleOauthClient;
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
+import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
@@ -32,7 +33,7 @@ public class GoogleOAuthService implements OAuthService {
    * @return
    */
   @Override
-  public String login(OAuthLoginRequest request) {
+  public UserSigninResDto login(OAuthLoginRequest request) {
     /* 토큰 발급을 위한 RestClient 요청*/
     OAuthTokenResponse token = googleClient.getToken(request.code());
 

--- a/src/main/java/com/education/takeit/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/KakaoOAuthService.java
@@ -10,14 +10,16 @@ import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.KakaoOauthClient;
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
+import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 import java.security.interfaces.RSAPublicKey;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +38,7 @@ public class KakaoOAuthService implements OAuthService {
    * @return
    */
   @Override
-  public String login(OAuthLoginRequest request) {
+  public UserSigninResDto login(OAuthLoginRequest request) {
     /* 토큰 발급을 위한 RestClient 요청*/
     OAuthTokenResponse token = kakaoClient.getToken(request.code());
 

--- a/src/main/java/com/education/takeit/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/KakaoOAuthService.java
@@ -14,12 +14,11 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.security.interfaces.RSAPublicKey;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/education/takeit/oauth/service/NaverOAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/NaverOAuthService.java
@@ -7,12 +7,14 @@ import com.education.takeit.oauth.client.NaverOauthClient;
 import com.education.takeit.oauth.dto.NaverUserResponse;
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
+import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +24,7 @@ public class NaverOAuthService implements OAuthService {
   private final JwtUtils jwtUtils;
 
   @Override
-  public String login(OAuthLoginRequest request) {
+  public UserSigninResDto login(OAuthLoginRequest request) {
     if (request.state() == null || request.state().isBlank()) {
       throw new CustomException(StatusCode.MISSING_NAVER_STATE);
     }

--- a/src/main/java/com/education/takeit/oauth/service/NaverOAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/NaverOAuthService.java
@@ -11,10 +11,9 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/education/takeit/oauth/service/OAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/OAuthService.java
@@ -3,7 +3,6 @@ package com.education.takeit.oauth.service;
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
 import com.education.takeit.user.dto.UserSigninResDto;
-
 import java.util.Map;
 
 public interface OAuthService {

--- a/src/main/java/com/education/takeit/oauth/service/OAuthService.java
+++ b/src/main/java/com/education/takeit/oauth/service/OAuthService.java
@@ -2,6 +2,8 @@ package com.education.takeit.oauth.service;
 
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
+import com.education.takeit.user.dto.UserSigninResDto;
+
 import java.util.Map;
 
 public interface OAuthService {
@@ -12,7 +14,7 @@ public interface OAuthService {
    * @param request
    * @return
    */
-  String login(OAuthLoginRequest request);
+  UserSigninResDto login(OAuthLoginRequest request);
 
   /**
    * 소셜 로그인 검증 로직 (서명 및 유효성 검사)

--- a/src/main/java/com/education/takeit/user/controller/UserController.java
+++ b/src/main/java/com/education/takeit/user/controller/UserController.java
@@ -69,10 +69,9 @@ public class UserController {
 
   @PostMapping("/refresh")
   @Operation(summary = "엑세스 토큰 재발급", description = "만료된 액세스 토큰 재발급 API")
-  public ResponseEntity<Message> refreshAccessToken(
-          @RequestParam String refreshToken) {
+  public ResponseEntity<Message> refreshAccessToken(@RequestParam String refreshToken) {
     Long userId = jwtUtils.getUserId(refreshToken);
-    if (!jwtUtils.validateRefreshToken(userId, refreshToken)){
+    if (!jwtUtils.validateRefreshToken(userId, refreshToken)) {
       return ResponseEntity.ok(new Message(StatusCode.UNAUTHORIZED));
     }
     String newAccessToken = jwtUtils.generateAccessToken(userId);

--- a/src/main/java/com/education/takeit/user/controller/UserController.java
+++ b/src/main/java/com/education/takeit/user/controller/UserController.java
@@ -4,8 +4,9 @@ import com.education.takeit.global.dto.Message;
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.security.CustomUserDetails;
 import com.education.takeit.global.security.JwtUtils;
-import com.education.takeit.user.dto.ReqSigninDto;
-import com.education.takeit.user.dto.ReqSignupDto;
+import com.education.takeit.user.dto.UserSigninReqDto;
+import com.education.takeit.user.dto.UserSigninResDto;
+import com.education.takeit.user.dto.UserSignupReqDto;
 import com.education.takeit.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,22 +28,22 @@ public class UserController {
 
   @PostMapping("/signup")
   @Operation(summary = "회원가입", description = "자체 서비스 회원가입 API")
-  public ResponseEntity<Message> signUp(@Valid @RequestBody ReqSignupDto reqSignupDto) {
-    userService.signUp(reqSignupDto);
+  public ResponseEntity<Message> signUp(@Valid @RequestBody UserSignupReqDto userSignupReqDto) {
+    userService.signUp(userSignupReqDto);
     return ResponseEntity.ok(new Message(StatusCode.OK));
   }
 
   @PostMapping("/signin")
   @Operation(summary = "로그인", description = "자체 서비스 로그인 API")
-  public ResponseEntity<Message> signIn(@RequestBody ReqSigninDto reqSigninDto) {
-    String accessToken = userService.signIn(reqSigninDto);
+  public ResponseEntity<Message> signIn(@RequestBody UserSigninReqDto userSigninReqDto) {
+    UserSigninResDto userSigninResDto = userService.signIn(userSigninReqDto);
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Authorization", "Bearer " + accessToken);
+    headers.add("Authorization", "Bearer " + userSigninResDto.accessToken());
 
     Message message = new Message(StatusCode.OK);
 
-    return ResponseEntity.ok().headers(headers).body(message);
+    return ResponseEntity.ok().headers(headers).body(new Message(StatusCode.OK, userSigninResDto));
   }
 
   @DeleteMapping("/signout")
@@ -64,5 +65,17 @@ public class UserController {
   public ResponseEntity<Message> Withdraw(@AuthenticationPrincipal CustomUserDetails principal) {
     userService.withdraw(principal.getUserId());
     return ResponseEntity.ok(new Message(StatusCode.OK));
+  }
+
+  @PostMapping("/refresh")
+  @Operation(summary = "엑세스 토큰 재발급", description = "만료된 액세스 토큰 재발급 API")
+  public ResponseEntity<Message> refreshAccessToken(
+          @RequestParam String refreshToken) {
+    Long userId = jwtUtils.getUserId(refreshToken);
+    if (!jwtUtils.validateRefreshToken(userId, refreshToken)){
+      return ResponseEntity.ok(new Message(StatusCode.UNAUTHORIZED));
+    }
+    String newAccessToken = jwtUtils.generateAccessToken(userId);
+    return ResponseEntity.ok(new Message(StatusCode.OK, newAccessToken));
   }
 }

--- a/src/main/java/com/education/takeit/user/dto/ReqSigninDto.java
+++ b/src/main/java/com/education/takeit/user/dto/ReqSigninDto.java
@@ -1,3 +1,0 @@
-package com.education.takeit.user.dto;
-
-public record ReqSigninDto(String email, String password) {}

--- a/src/main/java/com/education/takeit/user/dto/UserSigninReqDto.java
+++ b/src/main/java/com/education/takeit/user/dto/UserSigninReqDto.java
@@ -1,0 +1,3 @@
+package com.education.takeit.user.dto;
+
+public record UserSigninReqDto(String email, String password) {}

--- a/src/main/java/com/education/takeit/user/dto/UserSigninResDto.java
+++ b/src/main/java/com/education/takeit/user/dto/UserSigninResDto.java
@@ -1,3 +1,3 @@
 package com.education.takeit.user.dto;
 
-public record UserSigninResDto (String accessToken, String refreshToken) {}
+public record UserSigninResDto(String accessToken, String refreshToken) {}

--- a/src/main/java/com/education/takeit/user/dto/UserSigninResDto.java
+++ b/src/main/java/com/education/takeit/user/dto/UserSigninResDto.java
@@ -1,0 +1,3 @@
+package com.education.takeit.user.dto;
+
+public record UserSigninResDto (String accessToken, String refreshToken) {}

--- a/src/main/java/com/education/takeit/user/dto/UserSignupReqDto.java
+++ b/src/main/java/com/education/takeit/user/dto/UserSignupReqDto.java
@@ -5,7 +5,7 @@ import com.education.takeit.user.entity.LoginType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record ReqSignupDto(
+public record UserSignupReqDto(
     @Email(message = "이메일 형식이 올바르지 않습니다.") @NotBlank(message = "이메일은 필수 항목입니다.") String email,
     @NotBlank(message = "닉네임은 필수 항목입니다.") String nickname,
     @ValidPassword String password,

--- a/src/main/java/com/education/takeit/user/service/UserService.java
+++ b/src/main/java/com/education/takeit/user/service/UserService.java
@@ -1,13 +1,14 @@
 package com.education.takeit.user.service;
 
-import com.education.takeit.user.dto.ReqSigninDto;
-import com.education.takeit.user.dto.ReqSignupDto;
+import com.education.takeit.user.dto.UserSigninReqDto;
+import com.education.takeit.user.dto.UserSigninResDto;
+import com.education.takeit.user.dto.UserSignupReqDto;
 
 public interface UserService {
 
-  void signUp(ReqSignupDto reqSignupDto);
+  void signUp(UserSignupReqDto userSignupReqDto);
 
-  String signIn(ReqSigninDto reqSigninDto);
+  UserSigninResDto signIn(UserSigninReqDto userSigninReqDto);
 
   void signOut(Long userId);
 
@@ -19,5 +20,5 @@ public interface UserService {
 
   Long extractUserId(String token);
 
-  boolean validateRefreshToken(Long userId);
+  boolean validateRefreshToken(Long userId, String refreshToken);
 }

--- a/src/main/java/com/education/takeit/user/service/UserServiceImpl.java
+++ b/src/main/java/com/education/takeit/user/service/UserServiceImpl.java
@@ -3,8 +3,9 @@ package com.education.takeit.user.service;
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
-import com.education.takeit.user.dto.ReqSigninDto;
-import com.education.takeit.user.dto.ReqSignupDto;
+import com.education.takeit.user.dto.UserSigninReqDto;
+import com.education.takeit.user.dto.UserSigninResDto;
+import com.education.takeit.user.dto.UserSignupReqDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
@@ -25,16 +26,16 @@ public class UserServiceImpl implements UserService {
   private final RedisTemplate<String, String> redisTemplate;
 
   @Override
-  public void signUp(ReqSignupDto reqSignupDto) {
-    if (userRepository.existsByEmailAndLoginType(reqSignupDto.email(), LoginType.LOCAL)) {
+  public void signUp(UserSignupReqDto userSignupReqDto) {
+    if (userRepository.existsByEmailAndLoginType(userSignupReqDto.email(), LoginType.LOCAL)) {
       throw new CustomException(StatusCode.ALREADY_EXIST_EMAIL);
     }
 
     User user =
         User.builder()
-            .email(reqSignupDto.email())
-            .nickname(reqSignupDto.nickname())
-            .password(passwordEncoder.encode(reqSignupDto.password()))
+            .email(userSignupReqDto.email())
+            .nickname(userSignupReqDto.nickname())
+            .password(passwordEncoder.encode(userSignupReqDto.password()))
             .loginType(LoginType.LOCAL)
             .build();
 
@@ -42,13 +43,13 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public String signIn(ReqSigninDto reqSigninDto) {
+  public UserSigninResDto signIn(UserSigninReqDto userSigninReqDto) {
     User user =
         userRepository
-            .findByEmailAndLoginType(reqSigninDto.email(), LoginType.LOCAL)
+            .findByEmailAndLoginType(userSigninReqDto.email(), LoginType.LOCAL)
             .orElseThrow(() -> new CustomException(StatusCode.NOT_EXIST_USER));
 
-    if (!passwordEncoder.matches(reqSigninDto.password(), user.getPassword())) {
+    if (!passwordEncoder.matches(userSigninReqDto.password(), user.getPassword())) {
       throw new CustomException(StatusCode.NOT_EXIST_USER);
     }
     return jwtUtils.generateTokens(user.getUserId());
@@ -106,7 +107,7 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public boolean validateRefreshToken(Long userId) {
-    return jwtUtils.validateRefreshToken(userId);
+  public boolean validateRefreshToken(Long userId, String refreshToken) {
+    return jwtUtils.validateRefreshToken(userId, refreshToken);
   }
 }

--- a/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -12,19 +16,14 @@ import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class GoogleOAuthServiceTest {
   private GoogleOauthClient googleOauthClient;
@@ -78,7 +77,8 @@ class GoogleOAuthServiceTest {
 
     when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(savedUser.getUserId())).thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
+    when(jwtUtils.generateTokens(savedUser.getUserId()))
+        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
 
     // when
     UserSigninResDto tokens = googleOAuthService.login(loginRequest);

--- a/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
@@ -1,5 +1,8 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.education.takeit.global.dto.StatusCode;
@@ -12,19 +15,15 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class KakaoOAuthServiceTest {
 
@@ -93,7 +92,8 @@ class KakaoOAuthServiceTest {
         User.builder().email(email).nickname(nickname).loginType(LoginType.KAKAO).build();
     when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(savedUser.getUserId())).thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
+    when(jwtUtils.generateTokens(savedUser.getUserId()))
+        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
 
     // when
     UserSigninResDto tokens = kakaoOAuthService.login(loginRequest);

--- a/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
@@ -1,21 +1,23 @@
 package com.education.takeit.oauth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.NaverOauthClient;
 import com.education.takeit.oauth.dto.NaverUserResponse;
 import com.education.takeit.oauth.dto.OAuthLoginRequest;
 import com.education.takeit.oauth.dto.OAuthTokenResponse;
+import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 public class NaverOAuthServiceTest {
   private NaverOauthClient naverOauthClient;
@@ -40,6 +42,7 @@ public class NaverOAuthServiceTest {
     OAuthTokenResponse tokenResponse =
         OAuthTokenResponse.builder()
             .accessToken("mock-access-token")
+            .refreshToken("mock-refresh-token")
             .tokenType("mock-token-type")
             .build();
 
@@ -63,12 +66,13 @@ public class NaverOAuthServiceTest {
     when(naverOauthClient.getUserInfo("mock-access-token")).thenReturn(userResponse);
     when(userRepository.findByEmailAndLoginType(userInfo.getEmail(), LoginType.NAVER))
         .thenReturn(Optional.of(mockUser));
-    when(jwtUtils.generateTokens(mockUser.getUserId())).thenReturn("mock-access-token");
+    when(jwtUtils.generateTokens(mockUser.getUserId())).thenReturn(new UserSigninResDto("mock-access-token", "mock-refresh-token"));
 
-    String tokens = naverOAuthService.login(loginRequest);
+    UserSigninResDto tokens = naverOAuthService.login(loginRequest);
 
     // then
-    assertThat(tokens).isEqualTo("mock-access-token");
+    assertThat(tokens.accessToken()).isEqualTo("mock-access-token");
+    assertThat(tokens.refreshToken()).isEqualTo("mock-refresh-token");
 
     // 메서드 호출 검증
     verify(naverOauthClient).getToken("mock-code", "mock-state");

--- a/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.NaverOauthClient;
@@ -10,14 +14,9 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
 
 public class NaverOAuthServiceTest {
   private NaverOauthClient naverOauthClient;
@@ -66,7 +65,8 @@ public class NaverOAuthServiceTest {
     when(naverOauthClient.getUserInfo("mock-access-token")).thenReturn(userResponse);
     when(userRepository.findByEmailAndLoginType(userInfo.getEmail(), LoginType.NAVER))
         .thenReturn(Optional.of(mockUser));
-    when(jwtUtils.generateTokens(mockUser.getUserId())).thenReturn(new UserSigninResDto("mock-access-token", "mock-refresh-token"));
+    when(jwtUtils.generateTokens(mockUser.getUserId()))
+        .thenReturn(new UserSigninResDto("mock-access-token", "mock-refresh-token"));
 
     UserSigninResDto tokens = naverOAuthService.login(loginRequest);
 

--- a/src/test/java/com/education/takeit/user/ReqSingupDtoTest.java
+++ b/src/test/java/com/education/takeit/user/ReqSingupDtoTest.java
@@ -2,7 +2,7 @@ package com.education.takeit.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.education.takeit.user.dto.ReqSignupDto;
+import com.education.takeit.user.dto.UserSignupReqDto;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -26,9 +26,9 @@ public class ReqSingupDtoTest {
   @DisplayName("회원가입 정상")
   void signup_success() {
     // given
-    ReqSignupDto dto = new ReqSignupDto("test@test.com", "nickname", "abc123!@", null);
+    UserSignupReqDto dto = new UserSignupReqDto("test@test.com", "nickname", "abc123!@", null);
     // when
-    Set<ConstraintViolation<ReqSignupDto>> violations = validator.validate(dto);
+    Set<ConstraintViolation<UserSignupReqDto>> violations = validator.validate(dto);
 
     // then
     assertThat(violations).isEmpty();
@@ -38,14 +38,14 @@ public class ReqSingupDtoTest {
   @DisplayName("회원가입 실패_비밀번호가 8자 미만이면 실패")
   void signup_failByPasswordShort() {
     // given
-    ReqSignupDto dto =
-        new ReqSignupDto(
+    UserSignupReqDto dto =
+        new UserSignupReqDto(
             "test@test.com",
             "nickname",
             "a1!", // 3자, 조합은 OK지만 길이 실패
             null);
     // when
-    Set<ConstraintViolation<ReqSignupDto>> violations = validator.validate(dto);
+    Set<ConstraintViolation<UserSignupReqDto>> violations = validator.validate(dto);
 
     // then
     assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("password"));
@@ -55,14 +55,14 @@ public class ReqSingupDtoTest {
   @DisplayName("회원가입 실패_비밀번호 3가지 문자 미만 포함 실패")
   void signup_failByPassword3() {
     // given
-    ReqSignupDto dto =
-        new ReqSignupDto(
+    UserSignupReqDto dto =
+        new UserSignupReqDto(
             "test@test.com",
             "nickname",
             "12345678", // 숫자만, 길이는 OK
             null);
     // when
-    Set<ConstraintViolation<ReqSignupDto>> violations = validator.validate(dto);
+    Set<ConstraintViolation<UserSignupReqDto>> violations = validator.validate(dto);
 
     // then
     assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("password"));

--- a/src/test/java/com/education/takeit/user/UserServiceTest.java
+++ b/src/test/java/com/education/takeit/user/UserServiceTest.java
@@ -1,19 +1,15 @@
 package com.education.takeit.user;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
-import com.education.takeit.user.dto.ReqSigninDto;
-import com.education.takeit.user.dto.ReqSignupDto;
+import com.education.takeit.user.dto.UserSigninReqDto;
+import com.education.takeit.user.dto.UserSigninResDto;
+import com.education.takeit.user.dto.UserSignupReqDto;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.education.takeit.user.service.UserServiceImpl;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +19,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -36,14 +38,14 @@ public class UserServiceTest {
 
   @InjectMocks private UserServiceImpl userService;
 
-  private ReqSignupDto signupDto;
-  private ReqSigninDto signinDto;
+  private UserSignupReqDto signupDto;
+  private UserSigninReqDto signinDto;
   private User user;
 
   @BeforeEach
   void setUp() {
-    signupDto = new ReqSignupDto("test@example.com", "nickname", "password", LoginType.LOCAL);
-    signinDto = new ReqSigninDto("test@example.com", "password");
+    signupDto = new UserSignupReqDto("test@example.com", "nickname", "password", LoginType.LOCAL);
+    signinDto = new UserSigninReqDto("test@example.com", "password");
     user =
         User.builder()
             .email("test@example.com")
@@ -89,12 +91,12 @@ public class UserServiceTest {
         .thenReturn(Optional.of(user));
     when(passwordEncoder.matches(signinDto.password(), user.getPassword())).thenReturn(true);
 
-    String fakeTokens = "fake-access-token";
+    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token","fake-refresh-token");
 
     when(jwtUtils.generateTokens(user.getUserId())).thenReturn(fakeTokens);
 
     // When
-    String tokens = userService.signIn(signinDto);
+    UserSigninResDto tokens = userService.signIn(signinDto);
 
     // Then
     assertThat(tokens).isEqualTo(fakeTokens);

--- a/src/test/java/com/education/takeit/user/UserServiceTest.java
+++ b/src/test/java/com/education/takeit/user/UserServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.user;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -10,6 +14,7 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.education.takeit.user.service.UserServiceImpl;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,12 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -91,7 +90,7 @@ public class UserServiceTest {
         .thenReturn(Optional.of(user));
     when(passwordEncoder.matches(signinDto.password(), user.getPassword())).thenReturn(true);
 
-    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token","fake-refresh-token");
+    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token", "fake-refresh-token");
 
     when(jwtUtils.generateTokens(user.getUserId())).thenReturn(fakeTokens);
 


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- AccessToken 재발급 로직 수정

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [ ] 기타 (직접 작성)

### 🔍 상세 내용
- 리프레시 토큰을 비교하여 엑세스 토큰을 재발급 해주는 기능 되살림
- 토큰이 유효하지 않을 경우 401에러 반환

## 🧪 테스트 방법 (선택)
- [x] 로컬 테스트 완료
- [x] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- 
