### PR TITLE
EDU-420 fix: accessToken 재발급 시 refreshToken을 쿠키에서 가져오도록 수정

### DIFF
--- a/src/main/java/com/education/takeit/global/security/JwtUtils.java
+++ b/src/main/java/com/education/takeit/global/security/JwtUtils.java
@@ -4,12 +4,13 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import java.security.Key;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/education/takeit/global/security/JwtUtils.java
+++ b/src/main/java/com/education/takeit/global/security/JwtUtils.java
@@ -4,13 +4,12 @@ import com.education.takeit.user.dto.UserSigninResDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
-
 import java.security.Key;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/education/takeit/user/controller/UserController.java
+++ b/src/main/java/com/education/takeit/user/controller/UserController.java
@@ -13,16 +13,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/user")
@@ -89,7 +88,8 @@ public class UserController {
   @Operation(summary = "엑세스 토큰 재발급", description = "만료된 액세스 토큰 재발급 API")
   public ResponseEntity<Message> refreshAccessToken(HttpServletRequest request) {
     // 1. 쿠키에서 refreshToken 추출
-    String refreshToken = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+    String refreshToken =
+        Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
             .filter(cookie -> "refreshToken".equals(cookie.getName()))
             .map(Cookie::getValue)
             .findFirst()
@@ -108,7 +108,7 @@ public class UserController {
     HttpHeaders headers = new HttpHeaders();
     headers.add("Authorization", "Bearer " + newAccessToken);
     return ResponseEntity.ok()
-            .headers(headers)
-            .body(new Message(StatusCode.OK, "accessToken : " + newAccessToken));
+        .headers(headers)
+        .body(new Message(StatusCode.OK, "accessToken : " + newAccessToken));
   }
 }


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- accessToken 재발급 시 refreshToken을 쿠키에서 가져오도록 수정

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [ ] 기타 (직접 작성)

### 🔍 상세 내용
- accessToken 재발급 시 refreshToken을 쿠키에서 가져오도록 수정

## 🧪 테스트 방법 (선택)
- [x] 로컬 테스트 완료
- [x] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- 
