### PR TITLE
Edu 442 fix: 해설 저장하는 과정에서 roadmap을 subId로만 불러오는 로직 수정

### DIFF
--- a/src/main/java/com/education/takeit/roadmap/repository/RoadmapRepository.java
+++ b/src/main/java/com/education/takeit/roadmap/repository/RoadmapRepository.java
@@ -3,8 +3,9 @@ package com.education.takeit.roadmap.repository;
 import com.education.takeit.roadmap.entity.Roadmap;
 import com.education.takeit.roadmap.entity.RoadmapManagement;
 import com.education.takeit.roadmap.entity.Subject;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
   List<Roadmap> findByRoadmapManagement_RoadmapManagementId(Long id);
@@ -13,5 +14,5 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
 
   Roadmap findBySubjectAndRoadmapManagement(Subject subject, RoadmapManagement roadmapManagement);
 
-  Roadmap findBySubject_SubId(Long subId);
+  Roadmap findBySubject_SubIdAndRoadmapManagement_UserId(Long subId, Long userId);
 }

--- a/src/main/java/com/education/takeit/roadmap/repository/RoadmapRepository.java
+++ b/src/main/java/com/education/takeit/roadmap/repository/RoadmapRepository.java
@@ -3,9 +3,8 @@ package com.education.takeit.roadmap.repository;
 import com.education.takeit.roadmap.entity.Roadmap;
 import com.education.takeit.roadmap.entity.RoadmapManagement;
 import com.education.takeit.roadmap.entity.Subject;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
   List<Roadmap> findByRoadmapManagement_RoadmapManagementId(Long id);

--- a/src/main/java/com/education/takeit/solution/service/SolutionService.java
+++ b/src/main/java/com/education/takeit/solution/service/SolutionService.java
@@ -13,10 +13,11 @@ import com.education.takeit.solution.entity.UserExamAnswer;
 import com.education.takeit.solution.repository.UserExamAnswerRepository;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -70,7 +71,7 @@ public class SolutionService {
       }
 
       int nth;
-      Roadmap roadmap = roadmapRepository.findBySubject_SubId(subject.getSubId());
+      Roadmap roadmap = roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(subject.getSubId(),userId);
       if (!isPre) {
         nth = roadmap.getPostSubmitCount() + 1;
       } else {

--- a/src/main/java/com/education/takeit/solution/service/SolutionService.java
+++ b/src/main/java/com/education/takeit/solution/service/SolutionService.java
@@ -13,11 +13,10 @@ import com.education.takeit.solution.entity.UserExamAnswer;
 import com.education.takeit.solution.repository.UserExamAnswerRepository;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -71,7 +70,9 @@ public class SolutionService {
       }
 
       int nth;
-      Roadmap roadmap = roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(subject.getSubId(),userId);
+      Roadmap roadmap =
+          roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(
+              subject.getSubId(), userId);
       if (!isPre) {
         nth = roadmap.getPostSubmitCount() + 1;
       } else {


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- 해설 저장하는 과정에서 roadmap을 subId로만 불러오는 로직 수정

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [ ] 기타 (직접 작성)

### 🔍 상세 내용
- roadmap을 조회하는 쿼리에서 subId로만 조회하는 로직 수정

## 🧪 테스트 방법 (선택)
- [x] 로컬 테스트 완료
- [x] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- 
