### PR TITLE
EDU-448 fix: 중복되는 해설 저장 메소드 제거 및 examId 저장 로직 수정

### DIFF
--- a/src/main/java/com/education/takeit/exam/controller/ExamController.java
+++ b/src/main/java/com/education/takeit/exam/controller/ExamController.java
@@ -63,7 +63,6 @@ public class ExamController {
     }
     Long userId = userDetails.getUserId();
     examService.submitPreExam(userId, examAnswerRes);
-    solutionService.saveAllUserSolutions(userId, examAnswerRes.answers(), true);
     recommendService.fetchAndSaveRecommendation(userId, examAnswerRes.subjectId());
     return ResponseEntity.ok(new Message<>(StatusCode.OK));
   }
@@ -104,7 +103,6 @@ public class ExamController {
     }
     Long userId = userDetails.getUserId();
     examService.submitPostExam(userId, examAnswerRes);
-    solutionService.saveAllUserSolutions(userId, examAnswerRes.answers(), false);
     return ResponseEntity.ok(new Message<>(StatusCode.OK));
   }
 }

--- a/src/main/java/com/education/takeit/exam/dto/ExamAnswerDto.java
+++ b/src/main/java/com/education/takeit/exam/dto/ExamAnswerDto.java
@@ -2,6 +2,7 @@ package com.education.takeit.exam.dto;
 
 public record ExamAnswerDto(
     Long examId,
+    String examContent,
     int chapterNum,
     String chapterName,
     String difficulty,

--- a/src/main/java/com/education/takeit/exam/repository/ExamRepository.java
+++ b/src/main/java/com/education/takeit/exam/repository/ExamRepository.java
@@ -3,6 +3,8 @@ package com.education.takeit.exam.repository;
 import com.education.takeit.exam.entity.Exam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExamRepository extends JpaRepository<Exam, Long> {
-  Exam findByExamId(Long examId);
+  Optional<Exam> findByExamContent(String examContent);
 }

--- a/src/main/java/com/education/takeit/exam/repository/ExamRepository.java
+++ b/src/main/java/com/education/takeit/exam/repository/ExamRepository.java
@@ -1,9 +1,8 @@
 package com.education.takeit.exam.repository;
 
 import com.education.takeit.exam.entity.Exam;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExamRepository extends JpaRepository<Exam, Long> {
   Optional<Exam> findByExamContent(String examContent);

--- a/src/main/java/com/education/takeit/exam/service/ExamService.java
+++ b/src/main/java/com/education/takeit/exam/service/ExamService.java
@@ -274,7 +274,7 @@ public class ExamService {
     for (ExamAnswerDto answer : answers) {
       Exam exam =
           examRepository
-              .findById(answer.examId())
+              .findByExamContent(answer.examContent())
               .orElseThrow(() -> new CustomException(StatusCode.EXAM_NOT_FOUND));
 
       UserExamAnswer entity =

--- a/src/main/java/com/education/takeit/solution/service/SolutionService.java
+++ b/src/main/java/com/education/takeit/solution/service/SolutionService.java
@@ -1,17 +1,14 @@
 package com.education.takeit.solution.service;
 
-import com.education.takeit.exam.dto.ExamAnswerDto;
 import com.education.takeit.exam.entity.Exam;
 import com.education.takeit.exam.repository.ExamRepository;
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
-import com.education.takeit.roadmap.entity.Roadmap;
 import com.education.takeit.roadmap.entity.Subject;
 import com.education.takeit.roadmap.repository.RoadmapRepository;
 import com.education.takeit.solution.dto.SolutionResDto;
 import com.education.takeit.solution.entity.UserExamAnswer;
 import com.education.takeit.solution.repository.UserExamAnswerRepository;
-import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,37 +56,37 @@ public class SolutionService {
         .collect(Collectors.toList());
   }
 
-  //중복되는 메소드라서 주석처리 하겠습니다. - Honey
+  // 중복되는 메소드라서 주석처리 하겠습니다. - Honey
 
-//  public void saveAllUserSolutions(Long userId, List<ExamAnswerDto> answers, boolean isPre) {
-//    User user = userRepository.findById(userId).orElseThrow();
-//
-//    for (ExamAnswerDto answer : answers) {
-//      Exam exam = examRepository.findByExamId(answer.examId());
-//      Subject subject = exam.getSubject();
-//      if (subject == null) {
-//        throw new CustomException(StatusCode.SUBJECT_NOT_FOUND);
-//      }
-//
-//      int nth;
-//      Roadmap roadmap =
-//          roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(
-//              subject.getSubId(), userId);
-//      if (!isPre) {
-//        nth = roadmap.getPostSubmitCount() + 1;
-//      } else {
-//        nth = 1;
-//      }
-//      UserExamAnswer userExamAnswer =
-//          UserExamAnswer.builder()
-//              .user(user)
-//              .subject(subject)
-//              .exam(exam)
-//              .userAnswer(answer.userAnswer())
-//              .isPre(isPre)
-//              .nth(nth)
-//              .build();
-//      userExamAnswerRepository.save(userExamAnswer);
-//    }
-//  }
+  //  public void saveAllUserSolutions(Long userId, List<ExamAnswerDto> answers, boolean isPre) {
+  //    User user = userRepository.findById(userId).orElseThrow();
+  //
+  //    for (ExamAnswerDto answer : answers) {
+  //      Exam exam = examRepository.findByExamId(answer.examId());
+  //      Subject subject = exam.getSubject();
+  //      if (subject == null) {
+  //        throw new CustomException(StatusCode.SUBJECT_NOT_FOUND);
+  //      }
+  //
+  //      int nth;
+  //      Roadmap roadmap =
+  //          roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(
+  //              subject.getSubId(), userId);
+  //      if (!isPre) {
+  //        nth = roadmap.getPostSubmitCount() + 1;
+  //      } else {
+  //        nth = 1;
+  //      }
+  //      UserExamAnswer userExamAnswer =
+  //          UserExamAnswer.builder()
+  //              .user(user)
+  //              .subject(subject)
+  //              .exam(exam)
+  //              .userAnswer(answer.userAnswer())
+  //              .isPre(isPre)
+  //              .nth(nth)
+  //              .build();
+  //      userExamAnswerRepository.save(userExamAnswer);
+  //    }
+  //  }
 }

--- a/src/main/java/com/education/takeit/solution/service/SolutionService.java
+++ b/src/main/java/com/education/takeit/solution/service/SolutionService.java
@@ -59,35 +59,37 @@ public class SolutionService {
         .collect(Collectors.toList());
   }
 
-  public void saveAllUserSolutions(Long userId, List<ExamAnswerDto> answers, boolean isPre) {
-    User user = userRepository.findById(userId).orElseThrow();
+  //중복되는 메소드라서 주석처리 하겠습니다. - Honey
 
-    for (ExamAnswerDto answer : answers) {
-      Exam exam = examRepository.findByExamId(answer.examId());
-      Subject subject = exam.getSubject();
-      if (subject == null) {
-        throw new CustomException(StatusCode.SUBJECT_NOT_FOUND);
-      }
-
-      int nth;
-      Roadmap roadmap =
-          roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(
-              subject.getSubId(), userId);
-      if (!isPre) {
-        nth = roadmap.getPostSubmitCount() + 1;
-      } else {
-        nth = 1;
-      }
-      UserExamAnswer userExamAnswer =
-          UserExamAnswer.builder()
-              .user(user)
-              .subject(subject)
-              .exam(exam)
-              .userAnswer(answer.userAnswer())
-              .isPre(isPre)
-              .nth(nth)
-              .build();
-      userExamAnswerRepository.save(userExamAnswer);
-    }
-  }
+//  public void saveAllUserSolutions(Long userId, List<ExamAnswerDto> answers, boolean isPre) {
+//    User user = userRepository.findById(userId).orElseThrow();
+//
+//    for (ExamAnswerDto answer : answers) {
+//      Exam exam = examRepository.findByExamId(answer.examId());
+//      Subject subject = exam.getSubject();
+//      if (subject == null) {
+//        throw new CustomException(StatusCode.SUBJECT_NOT_FOUND);
+//      }
+//
+//      int nth;
+//      Roadmap roadmap =
+//          roadmapRepository.findBySubject_SubIdAndRoadmapManagement_UserId(
+//              subject.getSubId(), userId);
+//      if (!isPre) {
+//        nth = roadmap.getPostSubmitCount() + 1;
+//      } else {
+//        nth = 1;
+//      }
+//      UserExamAnswer userExamAnswer =
+//          UserExamAnswer.builder()
+//              .user(user)
+//              .subject(subject)
+//              .exam(exam)
+//              .userAnswer(answer.userAnswer())
+//              .isPre(isPre)
+//              .nth(nth)
+//              .build();
+//      userExamAnswerRepository.save(userExamAnswer);
+//    }
+//  }
 }


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- 중복되는 해설 저장 메소드 제거 및 examId 저장 로직 수정

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [ ] 기타 (직접 작성)

### 🔍 상세 내용
- 해설 정보를 저장하는 메소드가 중복되어 DB에 두번씩 저장되는 문제 해결
- 사용자가 푼 문제를 저장하는 examId가 잘못 저장되는 오류 수정

## 🧪 테스트 방법 (선택)
- [ ] 로컬 테스트 완료
- [x] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- 
