### PR TITLE
Edu 546 fix: HicariCP idle 값 50으로 수정 및 tomcat 타임 아웃 시간 2분으로 수정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,11 +10,11 @@ spring:
     password: ${MYSQL_PASSWORD}
 
     hikari:
-      maximum-pool-size: 50       # 최대 커넥션 수 (기본값 10)
-      minimum-idle: 5             # 최소 유휴 커넥션 수
-      idle-timeout: 900000        # 커넥션이 유휴 상태로 유지되는 최대 시간 (밀리초)
-      max-lifetime: 1800000       # 커넥션 생존 시간 (30분)
-      connection-timeout: 900000   # 커넥션 풀에서 커넥션을 얻기까지 기다리는 최대 시간 (30초)
+      maximum-pool-size: 50       # 최대 커넥션 수
+      minimum-idle: 50            # 최소 유휴 커넥션 수
+      idle-timeout: 90000         # 커넥션이 유휴 상태로 유지되는 최대 시간 (밀리초)
+      max-lifetime: 1800000       # 커넥션 생존 시간
+      connection-timeout: 90000  # 커넥션 풀에서 커넥션을 얻기까지 기다리는 최대 시간
       validation-timeout: 5000    # 커넥션 유효성 검사 타임아웃
 
   jpa:
@@ -90,3 +90,7 @@ logging:
     com.zaxxer.hikari.HikariDataSource: DEBUG
     # 커넥션 획득/반환 및 풀 상태 확인 로그
     hikari.HikariPool: DEBUG
+
+server:
+  tomcat:
+    connection-timeout: 120000 # 요청 타임아웃 시간 2분

--- a/src/test/java/com/education/takeit/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/education/takeit/feedback/service/FeedbackServiceTest.java
@@ -1,5 +1,8 @@
 package com.education.takeit.feedback.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
 import com.education.takeit.feedback.dto.FeedbackDto;
 import com.education.takeit.feedback.dto.FeedbackResponseDto;
 import com.education.takeit.feedback.dto.InfoDto;
@@ -17,19 +20,15 @@ import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FeedbackServiceTest {

--- a/src/test/java/com/education/takeit/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/education/takeit/feedback/service/FeedbackServiceTest.java
@@ -1,8 +1,5 @@
 package com.education.takeit.feedback.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.*;
-
 import com.education.takeit.feedback.dto.FeedbackDto;
 import com.education.takeit.feedback.dto.FeedbackResponseDto;
 import com.education.takeit.feedback.dto.InfoDto;
@@ -15,19 +12,24 @@ import com.education.takeit.roadmap.entity.Subject;
 import com.education.takeit.roadmap.entity.Track;
 import com.education.takeit.roadmap.repository.SubjectRepository;
 import com.education.takeit.user.entity.LoginType;
+import com.education.takeit.user.entity.Role;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FeedbackServiceTest {
@@ -42,7 +44,7 @@ class FeedbackServiceTest {
 
   private final Track track = new Track();
   private final User dummyUser =
-      new User("test@test.com", "testUser", "test", LoginType.LOCAL, "USER");
+      new User("test@test.com", "testUser", "test", LoginType.LOCAL, Role.USER);
   private final Subject dummySubject =
       Subject.builder()
           .subNm("Java")

--- a/src/test/java/com/education/takeit/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/education/takeit/interview/service/InterviewServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.interview.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.*;
+
 import com.education.takeit.global.client.AIClient;
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
@@ -15,23 +19,18 @@ import com.education.takeit.roadmap.repository.SubjectRepository;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class InterviewServiceTest {
@@ -266,7 +265,5 @@ public class InterviewServiceTest {
     verify(aiClient, times(1)).getInterviewFeedback(eq(userId), eq(requestList));
     verify(interviewRepository, times(5)).findById(anyLong());
     verify(replyRepository, times(1)).saveAll(anyList());
-
-
   }
 }

--- a/src/test/java/com/education/takeit/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/education/takeit/interview/service/InterviewServiceTest.java
@@ -1,9 +1,5 @@
 package com.education.takeit.interview.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.Mockito.*;
-
 import com.education.takeit.global.client.AIClient;
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
@@ -19,18 +15,23 @@ import com.education.takeit.roadmap.repository.SubjectRepository;
 import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class InterviewServiceTest {
@@ -138,6 +139,9 @@ public class InterviewServiceTest {
             .user(user)
             .aiFeedback("AI 피드백")
             .nth(1)
+            .summary("개념 요약")
+            .modelAnswer("모범 답변")
+            .keyword("특정 키워드")
             .build();
 
     List<UserInterviewReply> replyList = List.of(reply);
@@ -154,7 +158,9 @@ public class InterviewServiceTest {
     assertThat(dto.nth()).isEqualTo(1);
     assertThat(dto.userReply()).isEqualTo("사용자 답변");
     assertThat(dto.aiFeedback()).isEqualTo("AI 피드백");
-    assertThat(dto.interviewAnswer()).isEqualTo("모범 답변");
+    assertThat(dto.modelAnswer()).isEqualTo("모범 답변");
+    assertThat(dto.summary()).isEqualTo("개념 요약");
+    assertThat(dto.keyword()).isEqualTo("특정 키워드");
 
     verify(replyRepository, times(1)).findByUser_UserId(userId);
   }
@@ -246,8 +252,6 @@ public class InterviewServiceTest {
     }
     when(aiClient.getInterviewFeedback(userId, requestList)).thenReturn(expectedFeedbacks);
 
-    when(replyRepository.save(any(UserInterviewReply.class))).thenReturn(null);
-
     InterviewAllReplyReqDto requestDto = new InterviewAllReplyReqDto(requestList, 1);
 
     // When
@@ -261,6 +265,8 @@ public class InterviewServiceTest {
     verify(userRepository).findById(userId);
     verify(aiClient, times(1)).getInterviewFeedback(eq(userId), eq(requestList));
     verify(interviewRepository, times(5)).findById(anyLong());
-    verify(replyRepository, times(5)).save(any(UserInterviewReply.class));
+    verify(replyRepository, times(1)).saveAll(anyList());
+
+
   }
 }

--- a/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -13,19 +17,14 @@ import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class GoogleOAuthServiceTest {
   private GoogleOauthClient googleOauthClient;
@@ -75,11 +74,17 @@ class GoogleOAuthServiceTest {
         .thenReturn(Optional.empty());
 
     User savedUser =
-        User.builder().email(email).nickname(nickname).loginType(LoginType.GOOGLE).role(Role.USER).build();
+        User.builder()
+            .email(email)
+            .nickname(nickname)
+            .loginType(LoginType.GOOGLE)
+            .role(Role.USER)
+            .build();
 
     when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
+    when(jwtUtils.generateTokens(
+            savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
         .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token", true));
 
     // when

--- a/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/GoogleOAuthServiceTest.java
@@ -1,9 +1,5 @@
 package com.education.takeit.oauth.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -17,14 +13,19 @@ import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GoogleOAuthServiceTest {
   private GoogleOauthClient googleOauthClient;
@@ -74,12 +75,12 @@ class GoogleOAuthServiceTest {
         .thenReturn(Optional.empty());
 
     User savedUser =
-        User.builder().email(email).nickname(nickname).loginType(LoginType.GOOGLE).build();
+        User.builder().email(email).nickname(nickname).loginType(LoginType.GOOGLE).role(Role.USER).build();
 
     when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(Role.USER, savedUser.getUserId(), savedUser.getPrivacyStatus()))
-        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
+    when(jwtUtils.generateTokens(savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
+        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token", true));
 
     // when
     UserSigninResDto tokens = googleOAuthService.login(loginRequest);

--- a/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
@@ -1,5 +1,8 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.education.takeit.global.dto.StatusCode;
@@ -13,19 +16,15 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.Role;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class KakaoOAuthServiceTest {
 
@@ -91,10 +90,16 @@ class KakaoOAuthServiceTest {
         .thenReturn(Optional.empty());
 
     User savedUser =
-        User.builder().email(email).nickname(nickname).loginType(LoginType.KAKAO).role(Role.USER).build();
+        User.builder()
+            .email(email)
+            .nickname(nickname)
+            .loginType(LoginType.KAKAO)
+            .role(Role.USER)
+            .build();
     when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
+    when(jwtUtils.generateTokens(
+            savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
         .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token", true));
 
     // when

--- a/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/KakaoOAuthServiceTest.java
@@ -1,8 +1,5 @@
 package com.education.takeit.oauth.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.education.takeit.global.dto.StatusCode;
@@ -16,15 +13,19 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.Role;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Optional;
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 class KakaoOAuthServiceTest {
 
@@ -90,11 +91,11 @@ class KakaoOAuthServiceTest {
         .thenReturn(Optional.empty());
 
     User savedUser =
-        User.builder().email(email).nickname(nickname).loginType(LoginType.KAKAO).build();
+        User.builder().email(email).nickname(nickname).loginType(LoginType.KAKAO).role(Role.USER).build();
     when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
-    when(jwtUtils.generateTokens(Role.USER, savedUser.getUserId(), savedUser.getPrivacyStatus()))
-        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token"));
+    when(jwtUtils.generateTokens(savedUser.getRole(), savedUser.getUserId(), savedUser.getPrivacyStatus()))
+        .thenReturn(new UserSigninResDto("new-mock-access-token", "new-mock-refresh-token", true));
 
     // when
     UserSigninResDto tokens = kakaoOAuthService.login(loginRequest);

--- a/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.oauth.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.NaverOauthClient;
@@ -11,14 +15,9 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.Role;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
 
 public class NaverOAuthServiceTest {
   private NaverOauthClient naverOauthClient;
@@ -68,7 +67,8 @@ public class NaverOAuthServiceTest {
     when(naverOauthClient.getUserInfo("mock-access-token")).thenReturn(userResponse);
     when(userRepository.findByEmailAndLoginType(userInfo.getEmail(), LoginType.NAVER))
         .thenReturn(Optional.of(mockUser));
-    when(jwtUtils.generateTokens(mockUser.getRole(), mockUser.getUserId(), mockUser.getPrivacyStatus()))
+    when(jwtUtils.generateTokens(
+            mockUser.getRole(), mockUser.getUserId(), mockUser.getPrivacyStatus()))
         .thenReturn(new UserSigninResDto("mock-access-token", "mock-refresh-token"));
 
     UserSigninResDto tokens = naverOAuthService.login(loginRequest);

--- a/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
+++ b/src/test/java/com/education/takeit/oauth/service/NaverOAuthServiceTest.java
@@ -1,9 +1,5 @@
 package com.education.takeit.oauth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
 import com.education.takeit.oauth.client.NaverOauthClient;
@@ -15,9 +11,14 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.Role;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 public class NaverOAuthServiceTest {
   private NaverOauthClient naverOauthClient;
@@ -59,6 +60,7 @@ public class NaverOAuthServiceTest {
             .email(userInfo.getEmail())
             .nickname(userInfo.getNickname())
             .loginType(LoginType.NAVER)
+            .role(Role.USER)
             .build();
 
     // when (login 메소드가 실행되기전에 mock 객체 동작을 설정)
@@ -66,7 +68,7 @@ public class NaverOAuthServiceTest {
     when(naverOauthClient.getUserInfo("mock-access-token")).thenReturn(userResponse);
     when(userRepository.findByEmailAndLoginType(userInfo.getEmail(), LoginType.NAVER))
         .thenReturn(Optional.of(mockUser));
-    when(jwtUtils.generateTokens(Role.USER, mockUser.getUserId(), mockUser.getPrivacyStatus()))
+    when(jwtUtils.generateTokens(mockUser.getRole(), mockUser.getUserId(), mockUser.getPrivacyStatus()))
         .thenReturn(new UserSigninResDto("mock-access-token", "mock-refresh-token"));
 
     UserSigninResDto tokens = naverOAuthService.login(loginRequest);
@@ -98,7 +100,7 @@ public class NaverOAuthServiceTest {
     // 토큰 요청 실패했을 때는 한번도 실행되면 안됨
     verify(naverOauthClient, never()).getUserInfo(any());
     verify(userRepository, never()).findByEmailAndLoginType(any(), any());
-    verify(jwtUtils, never()).generateTokens(Role.USER, any(), any());
+    verify(jwtUtils, never()).generateTokens(eq(Role.USER), any(), any());
   }
 
   @Test
@@ -111,7 +113,7 @@ public class NaverOAuthServiceTest {
 
     verify(naverOauthClient, never()).getToken(any(), any());
     verify(userRepository, never()).findByEmailAndLoginType(any(), any());
-    verify(jwtUtils, never()).generateTokens(Role.USER, any(), any());
+    verify(jwtUtils, never()).generateTokens(eq(Role.USER), any(), any());
   }
 
   @Test
@@ -136,6 +138,6 @@ public class NaverOAuthServiceTest {
     verify(naverOauthClient).getToken("mock-code", "mock-state");
     verify(naverOauthClient).getUserInfo("mock-access-token");
     verify(userRepository, never()).findByEmailAndLoginType(any(), any());
-    verify(jwtUtils, never()).generateTokens(Role.USER, any(), any());
+    verify(jwtUtils, never()).generateTokens(eq(Role.USER), any(), any());
   }
 }

--- a/src/test/java/com/education/takeit/recommend/RecommendServiceTest.java
+++ b/src/test/java/com/education/takeit/recommend/RecommendServiceTest.java
@@ -1,5 +1,11 @@
 package com.education.takeit.recommend;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.kafka.recommand.dto.RecomResultDto;
@@ -14,6 +20,9 @@ import com.education.takeit.roadmap.entity.Track;
 import com.education.takeit.roadmap.repository.SubjectRepository;
 import com.education.takeit.user.entity.*;
 import com.education.takeit.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,16 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class RecommendServiceTest {

--- a/src/test/java/com/education/takeit/recommend/RecommendServiceTest.java
+++ b/src/test/java/com/education/takeit/recommend/RecommendServiceTest.java
@@ -1,11 +1,5 @@
 package com.education.takeit.recommend;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.kafka.recommand.dto.RecomResultDto;
@@ -18,14 +12,8 @@ import com.education.takeit.recommend.service.RecommendService;
 import com.education.takeit.roadmap.entity.Subject;
 import com.education.takeit.roadmap.entity.Track;
 import com.education.takeit.roadmap.repository.SubjectRepository;
-import com.education.takeit.user.entity.LectureAmount;
-import com.education.takeit.user.entity.LoginType;
-import com.education.takeit.user.entity.PriceLevel;
-import com.education.takeit.user.entity.User;
+import com.education.takeit.user.entity.*;
 import com.education.takeit.user.repository.UserRepository;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +21,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class RecommendServiceTest {
@@ -152,7 +150,7 @@ public class RecommendServiceTest {
   @DisplayName("사용자 추천 컨텐츠 저장 성공")
   void 사옹자_추천_컨텐츠_저장_성공() {
     // given
-    User user = new User("test@test.com", "test", "password", LoginType.LOCAL, "USER");
+    User user = new User("test@test.com", "test", "password", LoginType.LOCAL, Role.USER);
 
     RecomResultDto recomResultDto =
         new RecomResultDto(
@@ -190,7 +188,7 @@ public class RecommendServiceTest {
   @DisplayName("추천 콘텐츠 저장 시 컨텐츠가 존재하지 않으면 예외 발생")
   void 추천_콘텐츠_저장_실패_컨텐츠_없음() {
     // given
-    User user = new User("test@test.com", "test", "password", LoginType.LOCAL, "USER");
+    User user = new User("test@test.com", "test", "password", LoginType.LOCAL, Role.USER);
 
     RecomResultDto dto =
         new RecomResultDto(

--- a/src/test/java/com/education/takeit/user/UserServiceTest.java
+++ b/src/test/java/com/education/takeit/user/UserServiceTest.java
@@ -1,9 +1,5 @@
 package com.education.takeit.user;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -14,7 +10,6 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.education.takeit.user.service.UserServiceImpl;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +19,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -90,7 +91,7 @@ public class UserServiceTest {
         .thenReturn(Optional.of(user));
     when(passwordEncoder.matches(signinDto.password(), user.getPassword())).thenReturn(true);
 
-    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token", "fake-refresh-token");
+    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token", "fake-refresh-token", true);
 
     when(jwtUtils.generateTokens(user.getRole(), user.getUserId(), user.getPrivacyStatus()))
         .thenReturn(fakeTokens);

--- a/src/test/java/com/education/takeit/user/UserServiceTest.java
+++ b/src/test/java/com/education/takeit/user/UserServiceTest.java
@@ -1,5 +1,9 @@
 package com.education.takeit.user;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import com.education.takeit.global.dto.StatusCode;
 import com.education.takeit.global.exception.CustomException;
 import com.education.takeit.global.security.JwtUtils;
@@ -10,6 +14,7 @@ import com.education.takeit.user.entity.LoginType;
 import com.education.takeit.user.entity.User;
 import com.education.takeit.user.repository.UserRepository;
 import com.education.takeit.user.service.UserServiceImpl;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,12 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -91,7 +90,8 @@ public class UserServiceTest {
         .thenReturn(Optional.of(user));
     when(passwordEncoder.matches(signinDto.password(), user.getPassword())).thenReturn(true);
 
-    UserSigninResDto fakeTokens = new UserSigninResDto("fake-access-token", "fake-refresh-token", true);
+    UserSigninResDto fakeTokens =
+        new UserSigninResDto("fake-access-token", "fake-refresh-token", true);
 
     when(jwtUtils.generateTokens(user.getRole(), user.getUserId(), user.getPrivacyStatus()))
         .thenReturn(fakeTokens);


### PR DESCRIPTION
## 📌 Pull Request 내용 요약

- HicariCP idle 값 50으로 수정 및 tomcat 타임 아웃 시간 2분으로 수정

## ✅ 주요 변경사항

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 코드 추가 (test)
- [ ] 기타 (직접 작성)

### 🔍 상세 내용
- HicariCP idle 값 50으로 수정 및 tomcat 타임 아웃 시간 2분으로 수정
- 로그인 테스트 코드 수정
- interview 테스트 코드 수정

## 🧪 테스트 방법 (선택)
- [x] 로컬 테스트 완료
- [x] CI 통과
- [ ] 스테이징 배포 확인

## 🙋 기타 참고사항
- 
